### PR TITLE
Fix uninitializes ports, fix missing bracket

### DIFF
--- a/XUiDesigner/src/XUiWritePlugin.c
+++ b/XUiDesigner/src/XUiWritePlugin.c
@@ -44,6 +44,9 @@ void print_plugin(XUiDesigner *designer) {
     char * a_outputs[16];
     int o = 0;
     bool parse_file = designer->is_faust_file ? true : designer->is_cc_file ? true : false;
+    
+    //the loaded json should have set all relevant data in the project
+    bool is_project = designer->is_project || designer->is_json_file;
     char *name = NULL;
     XFetchName(designer->ui->app->dpy, designer->ui->widget, &name);
     if (name == NULL) asprintf(&name, "%s", "noname");
@@ -92,7 +95,7 @@ void print_plugin(XUiDesigner *designer) {
     }
 
     int i = 0;
-    if (designer->is_project) {
+    if ( is_project ) {
         for (;i<designer->lv2c.audio_input;i++) {
             printf ("    float* input%i;\n", i);
             asprintf((char**)&a_inputs[a],"input%i", i);
@@ -191,7 +194,7 @@ void print_plugin(XUiDesigner *designer) {
     printf ("// constructor\n"
     "X%s::X%s() :\n", name, name);
     bool add_comma = false;
-    if (designer->is_project) {
+    if (is_project) {
         i = 0;
         for (;i<designer->lv2c.audio_input;i++) {
             printf ("%s\n    input%i(NULL)", add_comma ? "," : "", i);
@@ -279,7 +282,7 @@ void print_plugin(XUiDesigner *designer) {
     "    {\n", name);
     i = 0;
     int p = 0;
-    if (designer->is_project) {
+    if (is_project) {
         for (;i<designer->lv2c.audio_input;i++) {
             printf ("        case %i:\n"
                     "            input%i = static_cast<float*>(data);\n"
@@ -498,6 +501,9 @@ void print_plugin(XUiDesigner *designer) {
         free(oports);
         oports = NULL;
     }
+    
+    if (designer->lv2c.bypass) 
+        printf ("    }\n\n");
     
     if (designer->lv2c.bypass) {
         if (designer->lv2c.audio_input != designer->lv2c.audio_output) {


### PR DESCRIPTION
I tried to generate a project from a json gui file. However, there were two problems: 
1) The ports in line 95 were not initializes because the designer was not set to 'is_project'. 
In my opinion, it makes no difference here, if it was a json file or a designer project as all information from json should have been added to the project. 
But I don't know, if the designer->is_project member is needed elsewhere as is, therefore I introduced a local variable.
2) In Line 485 a condition is opened when the lv2 bypass is present. This was never closed.